### PR TITLE
🔑 add custom exception for invalid key

### DIFF
--- a/src/langchain_dartmouth/base.py
+++ b/src/langchain_dartmouth/base.py
@@ -1,16 +1,20 @@
 import dartmouth_auth
-
+from langchain_dartmouth.exceptions import InvalidKeyError
 
 class AuthenticatedMixin:
     """A mix-in class to faciliate authentication"""
 
     def authenticate(self, jwt_url=None):
-        if self.authenticator:
-            jwt = self.authenticator()
-        else:
-            jwt = dartmouth_auth.get_jwt(
-                dartmouth_api_key=self.dartmouth_api_key, jwt_url=jwt_url
-            )
+        try:
+            if self.authenticator:
+                jwt = self.authenticator()
+            else:
+                jwt = dartmouth_auth.get_jwt(
+                    dartmouth_api_key=self.dartmouth_api_key, jwt_url=jwt_url
+                )
+        except KeyError as e:
+            raise InvalidKeyError from e
+
         auth_header = {"Authorization": f"Bearer {jwt}"}
         self._set_extra_headers(auth_header)
 

--- a/src/langchain_dartmouth/exceptions.py
+++ b/src/langchain_dartmouth/exceptions.py
@@ -1,2 +1,6 @@
 class ModelNotFoundError(Exception):
     pass
+
+
+class InvalidKeyError(KeyError):
+    pass

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -9,7 +9,7 @@ from langchain_dartmouth.llms import (
     ChatDartmouthCloud,
 )
 from langchain_dartmouth.embeddings import DartmouthEmbeddings
-from langchain_dartmouth.exceptions import ModelNotFoundError
+from langchain_dartmouth.exceptions import InvalidKeyError, ModelNotFoundError
 from langchain_dartmouth.cross_encoders import TextEmbeddingInferenceClient
 from langchain_dartmouth.retrievers.document_compressors import (
     TeiCrossEncoderReranker,
@@ -112,10 +112,22 @@ def test_chat_dartmouth_bad_name():
         llm.invoke("Who are you?")
 
 
+def test_chat_dartmouth_bad_key():
+    with pytest.raises(InvalidKeyError):
+        ChatDartmouth(dartmouth_api_key="Bad")
+
+
 def test_chat_dartmouth_cloud_bad_name():
     llm = ChatDartmouthCloud(model_name="Bad name")
 
     with pytest.raises(ModelNotFoundError):
+        llm.invoke("Who are you?")
+
+
+def test_chat_dartmouth_cloud_bad_key():
+    llm = ChatDartmouthCloud(dartmouth_chat_api_key="Bad")
+
+    with pytest.raises(InvalidKeyError):
         llm.invoke("Who are you?")
 
 


### PR DESCRIPTION
If an invalid key is provided, an `InvalidKeyError` is raised in all classes. Previously, the exception type depended on whatever type the internal client in each class would use. This standardizes the behavior and makes the code more consistent. Closes #26 