### PR TITLE
Cloud embeddings

### DIFF
--- a/src/langchain_dartmouth/embeddings.py
+++ b/src/langchain_dartmouth/embeddings.py
@@ -16,19 +16,14 @@ class DartmouthEmbeddings(OpenAIEmbeddings):
     :type model_name: str, optional
     :param model_kwargs: Keyword arguments to pass to the model.
     :type model_kwargs: dict, optional
-    :param dartmouth_api_key: A Dartmouth API key (obtainable from https://developer.dartmouth.edu). If not specified, it is attempted to be inferred from an environment variable ``DARTMOUTH_API_KEY``.
-    :type dartmouth_api_key: str, optional
-    :param authenticator: A Callable returning a JSON Web Token (JWT) for authentication. Only needed for special use cases.
-    :type authenticator: Callable, optional
-    :param jwt_url: URL of the Dartmouth API endpoint returning a JSON Web Token (JWT).
-    :type jwt_url: str, optional
-    :param embeddings_server_url: URL pointing to an embeddings endpoint, defaults to ``"https://ai-api.dartmouth.edu/tei/"``.
+    :param dartmouth_chat_api_key: A Dartmouth Chat API key (obtainable from `https://chat.dartmouth.edu <https://chat.dartmouth.edu>`_). If not specified, it is attempted to be inferred from an environment variable ``DARTMOUTH_CHAT_API_KEY``.
+    :param embeddings_server_url: URL pointing to an embeddings endpoint, defaults to ``"https://chat.dartmouth.edu/api/"``.
     :type embeddings_server_url: str, optional
 
     Example
     -----------
 
-    With an environment variable named ``DARTMOUTH_API_KEY`` pointing to your key obtained from `https://developer.dartmouth.edu <https://developer.dartmouth.edu>`_, using a Dartmouth-hosted embedding model only takes a few lines of code:
+    With an environment variable named ``DARTMOUTH_CHAT_API_KEY`` pointing to your key obtained from `Dartmouth Chat <https://chat.dartmouth.edu>`_, using anembedding model only takes a few lines of code:
 
     .. code-block:: python
 
@@ -83,15 +78,12 @@ class DartmouthEmbeddings(OpenAIEmbeddings):
     @staticmethod
     def list(
         dartmouth_chat_api_key: str | None = None,
-        base_only: bool = True,
         url: str = CLOUD_BASE_URL,
     ) -> list[dict]:
         """List the models available through ``DartmouthEmbeddings``.
 
         :param dartmouth_chat_api_key: A Dartmouth Chat API key (obtainable from `https://chat.dartmouth.edu <https://chat.dartmouth.edu>`_). If not specified, it is attempted to be inferred from an environment variable ``DARTMOUTH_CHAT_API_KEY``.
         :type dartmouth_chat_api_key: str, optional
-        :param base_only: If True, only regular Large Language Models are returned. If False, Workspace models are also returned.
-        :type base_only: bool, optional
         :param url: URL of the listing server
         :type url: str, optional
         :return: A list of descriptions of the available models
@@ -105,7 +97,8 @@ class DartmouthEmbeddings(OpenAIEmbeddings):
                 "Dartmouth Chat API key not provided as argument or defined as environment variable 'DARTMOUTH_CHAT_API_KEY'."
             ) from e
         listing = CloudModelListing(api_key=dartmouth_chat_api_key, url=url)
-        models = listing.list(base_only=base_only)
+        # Embedding models can't be workspace models, so hardcode to base-only
+        models = listing.list(base_only=True)
         # Some /models endpoints return the model list in a field:
         if "data" in models:
             models = models["data"]

--- a/src/langchain_dartmouth/embeddings.py
+++ b/src/langchain_dartmouth/embeddings.py
@@ -1,15 +1,15 @@
 from langchain_dartmouth.definitions import USER_AGENT
-from langchain_huggingface.embeddings import HuggingFaceEndpointEmbeddings
-
+from langchain_openai import OpenAIEmbeddings
+from openai import DefaultHttpxClient, DefaultAsyncHttpxClient
 import os
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
-from langchain_dartmouth.base import AuthenticatedMixin
-from langchain_dartmouth.definitions import EMBEDDINGS_BASE_URL, MODEL_LISTING_BASE_URL
-from langchain_dartmouth.model_listing import DartmouthModelListing
+from langchain_dartmouth.definitions import CLOUD_BASE_URL
+from langchain_dartmouth.model_listing import CloudModelListing
+from langchain_dartmouth.utils import filter_dartmouth_chat_models
 
 
-class DartmouthEmbeddings(HuggingFaceEndpointEmbeddings, AuthenticatedMixin):
+class DartmouthEmbeddings(OpenAIEmbeddings):
     """Embedding models deployed on Dartmouth's cluster.
 
     :param model_name: The name of the embedding model to use, defaults to ``"bge-large-en-v1-5"``.
@@ -42,57 +42,77 @@ class DartmouthEmbeddings(HuggingFaceEndpointEmbeddings, AuthenticatedMixin):
         print(response)
     """
 
-    authenticator: Optional[Callable] = None
-    dartmouth_api_key: Optional[str] = None
-    jwt_url: Optional[str] = None
+    dartmouth_chat_api_key: Optional[str] = None
     embeddings_server_url: Optional[str] = None
 
     def __init__(
         self,
         model_name: str = "bge-large-en-v1-5",
         model_kwargs: Optional[dict] = None,
-        dartmouth_api_key: Optional[str] = None,
+        dartmouth_chat_api_key: Optional[str] = None,
         authenticator: Optional[Callable] = None,
-        jwt_url: Optional[str] = None,
-        embeddings_server_url: Optional[str] = None,
+        embeddings_server_base_url: Optional[str] = None,
     ):
         """Initializes the object"""
-        if embeddings_server_url:
-            endpoint = f"{embeddings_server_url}{model_name}/"
+        kwargs: dict[str, Any] = dict()
+        kwargs["default_headers"] = {"User-Agent": USER_AGENT}
+        kwargs["model"] = model_name
+        if embeddings_server_base_url is not None:
+            kwargs["openai_api_base"] = embeddings_server_base_url
         else:
-            endpoint = f"{EMBEDDINGS_BASE_URL}{model_name}/"
-        super().__init__(model=endpoint, model_kwargs=model_kwargs)
-        self.client.headers.update({"User-Agent": USER_AGENT})
-        self.async_client.headers.update({"User-Agent": USER_AGENT})
-        self.authenticator = authenticator
-        self.dartmouth_api_key = dartmouth_api_key
-        self.authenticate(jwt_url=jwt_url)
+            kwargs["openai_api_base"] = f"{CLOUD_BASE_URL}"
+        if dartmouth_chat_api_key is None:
+            try:
+                dartmouth_chat_api_key = os.environ["DARTMOUTH_CHAT_API_KEY"]
+            except KeyError as e:
+                raise KeyError(
+                    "Dartmouth Chat API key not provided as argument or defined as environment variable 'DARTMOUTH_CHAT_API_KEY'."
+                ) from e
+
+        kwargs["openai_api_key"] = dartmouth_chat_api_key
+
+        super().__init__(
+            **kwargs,
+            # Turn off following redirects, see issue #8
+            http_async_client=DefaultAsyncHttpxClient(follow_redirects=False),
+            http_client=DefaultHttpxClient(follow_redirects=False),
+        )
+
+        self.dartmouth_chat_api_key = dartmouth_chat_api_key
 
     @staticmethod
     def list(
-        dartmouth_api_key: str = None, url: str = MODEL_LISTING_BASE_URL
+        dartmouth_chat_api_key: str | None = None,
+        base_only: bool = True,
+        url: str = CLOUD_BASE_URL,
     ) -> list[dict]:
         """List the models available through ``DartmouthEmbeddings``.
 
-        :param dartmouth_api_key: A Dartmouth API key (obtainable from https://developer.dartmouth.edu). If not specified, it is attempted to be inferred from an environment variable ``DARTMOUTH_API_KEY``.
-        :type dartmouth_api_key: str, optional
+        :param dartmouth_chat_api_key: A Dartmouth Chat API key (obtainable from `https://chat.dartmouth.edu <https://chat.dartmouth.edu>`_). If not specified, it is attempted to be inferred from an environment variable ``DARTMOUTH_CHAT_API_KEY``.
+        :type dartmouth_chat_api_key: str, optional
+        :param base_only: If True, only regular Large Language Models are returned. If False, Workspace models are also returned.
+        :type base_only: bool, optional
         :param url: URL of the listing server
         :type url: str, optional
         :return: A list of descriptions of the available models
         :rtype: list[dict]
         """
         try:
-            if dartmouth_api_key is None:
-                dartmouth_api_key = os.environ["DARTMOUTH_API_KEY"]
+            if dartmouth_chat_api_key is None:
+                dartmouth_chat_api_key = os.environ["DARTMOUTH_CHAT_API_KEY"]
         except KeyError as e:
             raise KeyError(
-                "Dartmouth API key not provided as argument or defined as environment variable 'DARTMOUTH_API_KEY'."
+                "Dartmouth Chat API key not provided as argument or defined as environment variable 'DARTMOUTH_CHAT_API_KEY'."
             ) from e
-        listing = DartmouthModelListing(api_key=dartmouth_api_key, url=url)
-        models = listing.list(server="text-embeddings-inference", type="embedding")
-        return models
+        listing = CloudModelListing(api_key=dartmouth_chat_api_key, url=url)
+        models = listing.list(base_only=base_only)
+        # Some /models endpoints return the model list in a field:
+        if "data" in models:
+            models = models["data"]
 
-    def embed_query(self, text: str) -> List[float]:
+        return filter_dartmouth_chat_models(models, include_tag="embedding")
+
+    def embed_query(self, text: str, **kwargs: Any) -> List[float]:
         """Call out to the embedding endpoint to retrieve the embedding of the query text.
 
         :param text: The text to embed.
@@ -100,13 +120,11 @@ class DartmouthEmbeddings(HuggingFaceEndpointEmbeddings, AuthenticatedMixin):
         :return: Embeddings for the text.
         :rtype: List[float]
         """
-        try:
-            return super().embed_query(text)
-        except Exception:
-            self.authenticate(jwt_url=self.jwt_url)
-            return super().embed_query(text)
+        return super().embed_query(text, **kwargs)
 
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+    def embed_documents(
+        self, texts: List[str], chunk_size: Optional[int] = None, **kwargs: Any
+    ) -> List[List[float]]:
         """Call out to the embedding endpoint to retrieve the embeddings of multiple texts.
 
         :param text: The list of texts to embed.
@@ -114,13 +132,9 @@ class DartmouthEmbeddings(HuggingFaceEndpointEmbeddings, AuthenticatedMixin):
         :return: Embeddings for the texts.
         :rtype: List[List[float]]
         """
-        try:
-            return super().embed_documents(texts)
-        except Exception:
-            self.authenticate(jwt_url=self.jwt_url)
-            return super().embed_documents(texts)
+        return super().embed_documents(texts, chunk_size, **kwargs)
 
-    async def aembed_query(self, text: str) -> List[float]:
+    async def aembed_query(self, text: str, **kwargs: Any) -> List[float]:
         """Async Call to the embedding endpoint to retrieve the embedding of the query text.
 
         :param text: The text to embed.
@@ -128,15 +142,12 @@ class DartmouthEmbeddings(HuggingFaceEndpointEmbeddings, AuthenticatedMixin):
         :return: Embeddings for the text.
         :rtype: List[float]
         """
-        try:
-            response = await super().aembed_query(text)
-            return response
-        except Exception:
-            self.authenticate(jwt_url=self.jwt_url)
-            response = await super().aembed_query(text)
-            return response
+        response = await super().aembed_query(text, **kwargs)
+        return response
 
-    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
+    async def aembed_documents(
+        self, texts: List[str], chunk_size: Optional[int] = None, **kwargs: Any
+    ) -> List[List[float]]:
         """Async Call to the embedding endpoint to retrieve the embeddings of multiple texts.
 
         :param text: The list of texts to embed.
@@ -144,14 +155,9 @@ class DartmouthEmbeddings(HuggingFaceEndpointEmbeddings, AuthenticatedMixin):
         :return: Embeddings for the texts.
         :rtype: List[List[float]]
         """
-        try:
-            response = await super().aembed_documents(texts)
-            return response
-        except Exception:
-            self.authenticate(jwt_url=self.jwt_url)
-            response = await super().aembed_documents(texts)
-            return response
+        response = await super().aembed_documents(texts, chunk_size, **kwargs)
+        return response
 
 
 if __name__ == "__main__":
-    print(DartmouthEmbeddings.list())
+    print([m["name"] for m in DartmouthEmbeddings.list()])

--- a/src/langchain_dartmouth/llms.py
+++ b/src/langchain_dartmouth/llms.py
@@ -17,7 +17,10 @@ from langchain_dartmouth.definitions import (
     MODEL_LISTING_BASE_URL,
 )
 from langchain_dartmouth.base import AuthenticatedMixin
-from langchain_dartmouth.utils import add_response_cost_to_usage_metadata
+from langchain_dartmouth.utils import (
+    add_response_cost_to_usage_metadata,
+    filter_dartmouth_chat_models,
+)
 from langchain_dartmouth.exceptions import InvalidKeyError, ModelNotFoundError
 from langchain_dartmouth.model_listing import (
     DartmouthModelListing,
@@ -773,16 +776,7 @@ class ChatDartmouthCloud(ChatOpenAI):
         if "data" in models:
             models = models["data"]
 
-        # Filter out some models better accessed through other means
-        def is_cloud_model(m):
-            return not (
-                m["id"].startswith("meta")
-                or m["id"].startswith("ollama.")
-                or ("is_active" in m and m["is_active"] is False)
-            )
-
-        models = [reformat_model_spec(m) for m in models if is_cloud_model(m)]
-        return models
+        return filter_dartmouth_chat_models(models, exclude_tag="embedding")
 
     def invoke(self, *args, **kwargs) -> BaseMessage:
         """Invokes the model to get a response to a query.

--- a/src/langchain_dartmouth/utils.py
+++ b/src/langchain_dartmouth/utils.py
@@ -1,3 +1,4 @@
+from typing import Any
 from langchain_core.messages import AIMessage
 
 
@@ -7,3 +8,60 @@ def add_response_cost_to_usage_metadata(response: AIMessage) -> AIMessage:
     if response_cost:
         response.usage_metadata["response_cost"] = response_cost
     return response
+
+
+def filter_dartmouth_chat_models(
+    models: list[dict[str, Any]],
+    include_tag: str | list[str] | None = None,
+    exclude_tag: str | list[str] | None = None,
+    include_capability: str | list[str] | None = None,
+    exclude_capability: str | list[str] | None = None,
+    active_only: bool = True,
+) -> list[dict[str, Any]]:
+
+    if active_only:
+        models = [m for m in models if m.get("is_active", True)]
+
+    def _has_tag(model, tag):
+        model_tags = model.get("meta", {}).get("tags")
+        if not model_tags:
+            return False
+
+        for model_tag in model_tags:
+            if tag.lower().strip() == model_tag["name"].lower().strip():
+                return True
+        return False
+
+    def _has_capability(model, capability):
+        model_capabilities = model.get("meta", {}).get("capabilities")
+        if capability.lower() in model_capabilities.keys():
+            return model[model_capabilities[capability]]
+        return False
+
+    if include_tag is not None:
+        if isinstance(include_tag, str):
+            include_tag = [include_tag]
+        for tag in include_tag:
+            models = [m for m in models if _has_tag(m, tag=tag)]
+
+    if exclude_tag is not None:
+        if isinstance(exclude_tag, str):
+            exclude_tag = [exclude_tag]
+        for tag in exclude_tag:
+            models = [m for m in models if not _has_tag(m, tag=tag)]
+
+    if include_capability is not None:
+        if isinstance(include_capability, str):
+            include_capability = [include_capability]
+        for capability in include_capability:
+            models = [m for m in models if _has_capability(m, capability=capability)]
+
+    if exclude_capability is not None:
+        if isinstance(exclude_capability, str):
+            exclude_capability = [exclude_capability]
+        for tag in exclude_capability:
+            models = [
+                m for m in models if not _has_capability(m, capability=capability)
+            ]
+
+    return models

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -16,8 +16,6 @@ from langchain_dartmouth.retrievers.document_compressors import (
     DartmouthReranker,
 )
 
-from langchain_dartmouth.utils import filter_dartmouth_chat_models
-
 from langchain.docstore.document import Document
 from langchain.schema import SystemMessage, HumanMessage
 


### PR DESCRIPTION
Migrate Embeddings to Dartmouth Chat API

## Overview
This PR migrates the [`DartmouthEmbeddings`](src/langchain_dartmouth/embeddings.py:12) class from the legacy HuggingFace-based endpoint to the new Dartmouth Chat API, aligning it with the existing [`ChatDartmouthCloud`](src/langchain_dartmouth/llms.py:617) implementation.

## Key Changes

### 1. Base Class Migration
- **Changed base class** from [`HuggingFaceEndpointEmbeddings`](src/langchain_dartmouth/embeddings.py:2) to [`OpenAIEmbeddings`](src/langchain_dartmouth/embeddings.py:2)
- Leverages OpenAI-compatible API format for better compatibility and maintainability

### 2. Authentication Updates
- **Replaced JWT authentication** with API key-based authentication
- Now uses `DARTMOUTH_CHAT_API_KEY` instead of `DARTMOUTH_API_KEY`
- Removed [`AuthenticatedMixin`](src/langchain_dartmouth/embeddings.py:12) dependency
- Simplified authentication flow by removing retry logic and JWT token management

### 3. Infrastructure Changes
- **Updated base URL** from `EMBEDDINGS_BASE_URL` to [`CLOUD_BASE_URL`](src/langchain_dartmouth/embeddings.py:24)
- **Updated model listing** to use [`CloudModelListing`](src/langchain_dartmouth/embeddings.py:48) instead of `DartmouthModelListing`
- Added HTTP client configuration with [`follow_redirects=False`](src/langchain_dartmouth/embeddings.py:76) to address redirect handling issues

### 4. Model Filtering Enhancement
- Added new [`filter_dartmouth_chat_models()`](src/langchain_dartmouth/utils.py:13) utility function in [`utils.py`](src/langchain_dartmouth/utils.py:1)
- Supports filtering by:
  - Tags (include/exclude)
  - Capabilities (include/exclude)
  - Active status
- Applied to both [`DartmouthEmbeddings.list()`](src/langchain_dartmouth/embeddings.py:84) and [`ChatDartmouthCloud.list()`](src/langchain_dartmouth/llms.py:779)

### 5. Method Signature Updates
- Updated [`embed_query()`](src/langchain_dartmouth/embeddings.py:115), [`embed_documents()`](src/langchain_dartmouth/embeddings.py:125), [`aembed_query()`](src/langchain_dartmouth/embeddings.py:137), and [`aembed_documents()`](src/langchain_dartmouth/embeddings.py:148) to accept `**kwargs`
- Added `chunk_size` parameter support for batched embedding operations
- Removed try-catch authentication retry logic (now handled by underlying client)

### 6. Test Improvements
- Changed model references from `model["name"]` to `model["id"]` for consistency
- Made test models configurable via [`STATIC_TEST_MODEL_ID`](tests/test_all.py:99) environment variable
- Added parametrized test [`test_dartmouth_embeddings()`](tests/test_all.py:193) that validates all available embedding models
- Improved error handling for missing API keys in tests

## Breaking Changes
⚠️ **Environment Variable Change**: Users must update from `DARTMOUTH_API_KEY` to `DARTMOUTH_CHAT_API_KEY`

⚠️ **Parameter Rename**: Constructor parameter changed from `dartmouth_api_key` to `dartmouth_chat_api_key`

## Benefits
- ✅ Unified authentication across LLM and embedding models
- ✅ Better model filtering capabilities with tag and capability support
- ✅ Simplified codebase by removing custom authentication logic
- ✅ Improved test coverage with parametrized embedding model tests
- ✅ Consistent API interface with Cloud infrastructure